### PR TITLE
Fixes and improvements for debian bullseye and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ fixed, `/usr/local/emacs/<version>/site-lisp` must be moved to
 `/usr/share/emacs-snapshot/site-lisp`. This is automatically handled by the
 `restore-emacs` script.
 
+# Using the restore-emacs script
+
+    usage: restore-emacs [--help] | [SRCDIR] [EMACSFLAVOR]
+    
+    Installs Emacs from SRCDIR as EMACSFLAVOR.
+    
+    Options:
+        -h, --help
+            show this message
+        SRCDIR:
+            Emacs source directory (default: current directory)
+        EMACSFLAVOR
+            name of the installed Emacs (default: emacs-snapshot)
+
 # Backwards Compatibility
 
 Compared to earlier versions of `restore-emacs`, the way Emacs is integrated

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Integrating Emacs built from source into Debian
 
-https://rrthomas@github.com/rrthomas/src-emacs-on-debian
+https://github.com/rrthomas/src-emacs-on-debian
 
 Maintainer: Reuben Thomas <rrt@sc3d.org>  
 Author: Michael Olson <mwolson@members.fsf.org>  
@@ -30,17 +30,33 @@ There are two parts to this kit:
 Also, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=840793
 
 In emacsen-common 2.0.8 at least (possibly earlier), and until the bug is
-fixed, `/usr/lib/emacsen-common/packages/install/emacsen-common` must be
-patched to make installation work; in emacsen-common 3.0.4 it’s at lines
-14–15, which read:
+fixed, `/usr/local/emacs/<version>/site-lisp` must be moved to
+`/usr/share/emacs-snapshot/site-lisp`. This is automatically handled by the
+`restore-emacs` script.
 
-```
-(cd /usr/share/${flavor}/site-lisp
-  ln -s ../../emacsen-common/debian-startup.el .)
-```
+# Backwards Compatibility
 
-   should be replaced with:
+Compared to earlier versions of `restore-emacs`, the way Emacs is integrated
+into the Debian Emacs management scripts has changed. The script has been tested
+for backwards compatibility. However, if you have previously used the
+`restore-emacs` it might be worth checking the following three directories:
 
-```
-ln -s /usr/share/emacsen-common/debian-startup.el /usr/share/${flavor}/site-lisp/
-```
+- `/etc/emacs-snapshot`: Previously, this was a directory containing
+  `site-start.d` as a symbolic link to `/etc/emacs/site-start.d`. Now,
+  `restore-emacs` just creates a symbolic link from `/etc/emacs-snapshot`
+  to `/etc/emacs`.
+- `/usr/share/emacs-snapshot`: Previously, this was a symbolic link to
+  `/usr/local/share/emacs/<version>`. Now, it is a local directory containing a
+  `site-start` directory and a symbolic link to `/usr/local/share/emacs/<version>`.
+- `/usr/local/share/emacs/site-lisp`: Is now a symbolic link to
+  `/usr/share/emacs-snapshot/site-start`.
+
+Normally, if you have not modified any of those directories manually and if you
+have not installed a different `emacs-snapshot` package (e.g. from the
+https://emacs.secretsauce.net/ project), it should be safe to delete them. They
+will be recreated with the new structure the next time you run `restore-emacs`.
+So, after careful checking, consider running the following:
+
+    sudo rm -r /etc/emacs-snapshot /usr/share/emacs-snapshot /usr/local/share/emacs/site-lisp
+
+just before using the updated `restore-emacs` script.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Emacs built from source into Debian or derivatives like Ubuntu.
 
 There are two parts to this kit:
 
-1. You should run `debian-init.el` early in your Emacs startup process
-   (I load it immediately after setting up `load-path`). It runs
-   Debian’s Emacs init files.
+1. The local `site-start.el` will be copied to the `site-lisp`
+   directory of the newly installed Emacs. It adds Debian specific
+   initialization steps to the Emacs startup sequence. E.g. it
+   configures elisp libraries installed as Debian packages.
 
 2. `restore-emacs` should be run every time you update your Emacs
    installed from source (e.g. with `git pull`), from the top-level

--- a/restore-emacs
+++ b/restore-emacs
@@ -18,7 +18,15 @@ SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 EMACS_FLAVOR='emacs-snapshot'
 DEB_PACKAGE="${EMACS_FLAVOR}_1.0_all.deb"
 
+SRC_SHARE_DIR="/usr/local/share/emacs"
+DST_SHARE_DIR="/usr/share/${EMACS_FLAVOR}"
+
 echo "[INF] Stage 1: Use 'make' to build/install Emacs from source tree ..."
+# remove potential (dangling?) symlink
+if [ -L "${SRC_SHARE_DIR}/site-lisp" ] &&
+   [ "$(realpath "${SRC_SHARE_DIR}/site-lisp")" != "${DST_SHARE_DIR}/site-lisp" ]; then
+    rm -v "${SRC_SHARE_DIR}/site-lisp"
+fi
 make install
 VERSION="$(realpath /usr/local/bin/emacs | cut -d'-' -f2)"
 echo "[INF] Stage 1: Done."
@@ -30,10 +38,89 @@ echo "[INF] Stage 2: Done."
 echo
 
 echo "[INF] Stage 3: Prepare Emacs ${VERSION} flavorization as ${EMACS_FLAVOR@Q} ..."
-ln -sfn "/usr/local/share/emacs/${VERSION}" "/usr/share/${EMACS_FLAVOR}"
-ln -sf /usr/local/bin/emacs "/usr/bin/${EMACS_FLAVOR}"
-mkdir -p "/etc/${EMACS_FLAVOR}/"
-ln -sf /etc/emacs/site-start.d "/etc/${EMACS_FLAVOR}"
+# The Debian package `emacsen-common` provides infrastructure which facilitates
+# the interworking between Emacs flavors (main Emacs packages providing the
+# actual binaries) and Emacs add-on packages (e.g. elisp libraries). The
+# `emacsen-common` package provides a description of how to use this
+# infrastructure in `/usr/share/doc/emacsen-common/debian-emacs-policy.gz`.
+#
+# The `emacsen-common` scripts register installed emacsen by creating the
+# `/var/lib/emacsen-common/state/flavor/<emacs-flavor>` file. This is then used
+# to make sure that each installed 'flavored' Emacs will 'see' installed elisp
+# packages. Tha process is managed by a couple of scripts in
+# `/usr/lib/emacsen-common/`. This section of restore-emacs tries to integrate
+# the newly installed Emacs with those management scripts.
+#
+# Debian elisp packages install .el files into `/usr/share/<package-name>/`. The
+# above mentioned Emacs management scripts then install symbolic links to these
+# elisp files into `/usr/share/<emacs-flavor>/site-lisp/`. Unfortunately, some
+# of these symlinks are relative. So just creating a symbolic link from
+# `/usr/share/<emacs-flavor>` to `/usr/local/share/emacs` directory is not an
+# option.
+#
+# See also: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=840793.
+#
+# As a workaround, create `/usr/share/<emacs-flavor>` as a directory and move
+# `/usr/local/share/emacs/site-lisp` to it. Then recreate
+# `/usr/local/share/emacs/site-lisp` as a symlink to
+# `/usr/share/<emacs-flavor>/site-lisp`.
+
+if [ -L "${DST_SHARE_DIR}" ]; then
+    rm -v "${DST_SHARE_DIR}" # just a symlink, should be save to remove
+fi
+mkdir -pv "${DST_SHARE_DIR}"
+
+# exit with an error check if the (potentially) existing symlink is not what we
+# expect or, if there is no symlink, do the shuffle described above
+if [ -L "${SRC_SHARE_DIR}/site-lisp" ]; then
+    if [ "$(realpath "${SRC_SHARE_DIR}/site-lisp")" != "${DST_SHARE_DIR}/site-lisp" ]; then
+        echo "[ERR] unexpected link target of '${SRC_SHARE_DIR}/site-lisp', expected"
+        echo "[ERR] '${DST_SHARE_DIR}/site-lisp', found '$(realpath "${SRC_SHARE_DIR}/site-lisp")'"
+        echo "[ERR] please check!"
+        exit 2
+    fi
+else
+    # move common site-lisp directory to /usr/share/<emacs-flavor>/
+    mv -v "${SRC_SHARE_DIR}/site-lisp" "${DST_SHARE_DIR}/"
+    # and replace its original location with a symlink to the moved directory
+    ln -sfnv "${DST_SHARE_DIR}/site-lisp" "${SRC_SHARE_DIR}/"
+fi
+
+# link versioned emacs installation directory into /usr/share/<emacs-flavor>/
+# (not necessary, but helps understanding where /usr/share/<emacs-flavor>/
+# originates from)
+ln -sfnv "${SRC_SHARE_DIR}/${VERSION}" "${DST_SHARE_DIR}/"
+
+# remove `debian-startup.el` installed using the instructions from a previous
+# version of this project
+if [ -f "${SRC_SHARE_DIR}/${VERSION}/site-lisp/debian-startup.el" ]; then
+    rm -fv "${SRC_SHARE_DIR}/${VERSION}/site-lisp/debian-startup".*
+fi
+
+# create am ${EMACS_FLAVOR} link in /usr/bin/ which targets the (versioned)
+# emacs binary in /usr/local/bin (see debian-emacs-policy section 6)
+ln -sfv "$(realpath "/usr/local/bin/emacs")" "/usr/bin/${EMACS_FLAVOR}"
+
+# symlink /etc/<emacs-flavor> to the /etc/emacs directory to allow
+# '/usr/share/<emacs-flavor>/site-lisp/debian-startup.el' (another part of the
+# Debian Emacs infrastructure) to do its work
+if [ -L "/etc/${EMACS_FLAVOR}" ]; then
+    # check for and allow 'legacy' directory structure, but exit if current
+    # directory structure is different from what is required
+    if [ "$(realpath "/etc/${EMACS_FLAVOR}")" != "/etc/emacs" ]; then
+        echo "[ERR] unexpected link target of '${SRC_SHARE_DIR}/site-lisp', expected"
+        echo "[ERR] '${DST_SHARE_DIR}/site-lisp', found '$(realpath "${SRC_SHARE_DIR}/site-lisp")'"
+        echo "[ERR] please check!"
+        exit 3
+    fi
+elif [ -d "/etc/${EMACS_FLAVOR}" ]; then
+    if [ "$(realpath "/etc/${EMACS_FLAVOR}/site-start.d")" != "/etc/emacs/site-start.d" ]; then
+        echo "[ERR] '/etc/${EMACS_FLAVOR}' should be a symlink to '/etc/emacs', please check"
+        exit 4
+    fi
+else
+    ln -sf "emacs" "/etc/${EMACS_FLAVOR}"
+fi
 echo "[INF] Stage 3: Done."
 echo
 

--- a/restore-emacs
+++ b/restore-emacs
@@ -12,17 +12,18 @@ if test "$UID" != "0"; then
     exit 1
 fi
 
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
 echo "Stage 1: Installing emacs ..."
 make install
+VERSION="$(realpath /usr/local/bin/emacs | cut -d'-' -f2)"
 
 echo "Stage 2: Install fake emacs-snapshot package ..."
-dpkg -i emacs-snapshot_1.0_all.deb
+dpkg -i "${SCRIPT_DIR}/emacs-snapshot_1.0_all.deb"
 
 echo "Done."
 echo "Stage 3: Making symlinks ..."
-latest=$(cd /usr/local/share/emacs && echo 2[3456789].* | tr ' ' '\n' | sort \
-    | tail -n 1)
-ln -sfn /usr/local/share/emacs/$latest /usr/share/emacs-snapshot
+ln -sfn "/usr/local/share/emacs/${VERSION}" /usr/share/emacs-snapshot
 ln -sf /usr/local/bin/emacs /usr/bin/emacs-snapshot
 mkdir -p /etc/emacs-snapshot/
 ln -sf /etc/emacs/site-start.d /etc/emacs-snapshot/

--- a/restore-emacs
+++ b/restore-emacs
@@ -1,35 +1,57 @@
-#!/bin/bash
-#
-# Restore custom-compiled emacs
+#!/usr/bin/env bash
+set -euo pipefail
+
+# restore custom-compiled emacs
 
 if test ! -d ./lisp/emacs-lisp; then
-    echo "You are not in the right directory."
+    echo "[ERR] You are not in the right directory."
     exit 1
 fi
 
 if test "$UID" != "0"; then
-    echo "You must be root to run this."
+    echo "[ERR] You must be root to run this."
     exit 1
 fi
 
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
+EMACS_FLAVOR='emacs-snapshot'
+DEB_PACKAGE="${EMACS_FLAVOR}_1.0_all.deb"
 
-echo "Stage 1: Installing emacs ..."
+echo "[INF] Stage 1: Use 'make' to build/install Emacs from source tree ..."
 make install
 VERSION="$(realpath /usr/local/bin/emacs | cut -d'-' -f2)"
+echo "[INF] Stage 1: Done."
+echo
 
-echo "Stage 2: Install fake emacs-snapshot package ..."
-dpkg -i "${SCRIPT_DIR}/emacs-snapshot_1.0_all.deb"
+echo "[INF] Stage 2: Install dummy ${DEB_PACKAGE} package ..."
+dpkg -i "${SCRIPT_DIR}/${DEB_PACKAGE}"
+echo "[INF] Stage 2: Done."
+echo
 
-echo "Done."
-echo "Stage 3: Making symlinks ..."
-ln -sfn "/usr/local/share/emacs/${VERSION}" /usr/share/emacs-snapshot
-ln -sf /usr/local/bin/emacs /usr/bin/emacs-snapshot
-mkdir -p /etc/emacs-snapshot/
-ln -sf /etc/emacs/site-start.d /etc/emacs-snapshot/
+echo "[INF] Stage 3: Prepare Emacs ${VERSION} flavorization as ${EMACS_FLAVOR@Q} ..."
+ln -sfn "/usr/local/share/emacs/${VERSION}" "/usr/share/${EMACS_FLAVOR}"
+ln -sf /usr/local/bin/emacs "/usr/bin/${EMACS_FLAVOR}"
+mkdir -p "/etc/${EMACS_FLAVOR}/"
+ln -sf /etc/emacs/site-start.d "/etc/${EMACS_FLAVOR}"
+echo "[INF] Stage 3: Done."
+echo
 
-echo "Done."
-echo "Stage 4: Installing emacs-snapshot flavor ..."
-/usr/lib/emacsen-common/emacs-install emacs-snapshot
+echo "[INF] Stage 4: Register/initialize Emacs flavor ${EMACS_FLAVOR@Q} ..."
+# run the Debian 'emacs-install' script to a) register the newly installed
+# ${EMACS_FLAVOR} with the Debian Emacs infrastructure scripts and b) add
+# already installed elisp packages to /usr/share/<emacs-flavor>/site-lisp.
+/usr/lib/emacsen-common/emacs-install "${EMACS_FLAVOR}"
+echo "[INF] Stage 4: Done."
+echo
 
-echo "Done."
+DST_SITE_START="/usr/local/share/emacs/${VERSION}/site-lisp/site-start.el"
+echo "[INF] Stage 5: Install/update ${DST_SITE_START@Q} ..."
+# copy the local site-start.el to /usr/local/share/emacs/<version>/site-lisp in
+# order to load '/usr/share/<emacs-flavor>/site-lisp/debian-startup.el' and run
+# the elisp `debian-startup' function during Emacs startup
+install --mode 644 --verbose "${SCRIPT_DIR}/site-start.el" "${DST_SITE_START}"
+echo "[INF] Stage 5: Done."
+echo
+
+echo "[INF] ${SCRIPT_NAME} finished successfully!"

--- a/restore-emacs
+++ b/restore-emacs
@@ -3,20 +3,72 @@ set -euo pipefail
 
 # restore custom-compiled emacs
 
-if test ! -d ./lisp/emacs-lisp; then
-    echo "[ERR] You are not in the right directory."
-    exit 1
-fi
-
-if test "$UID" != "0"; then
-    echo "[ERR] You must be root to run this."
-    exit 1
-fi
-
-SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
-EMACS_FLAVOR='emacs-snapshot'
-DEB_PACKAGE="${EMACS_FLAVOR}_1.0_all.deb"
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+usage() {
+    cat <<-EOU
+usage: ${SCRIPT_NAME} [--help] | [SRCDIR] [EMACSFLAVOR]
+
+Installs Emacs from SRCDIR as EMACSFLAVOR.
+
+Options:
+    -h, --help
+        show this message
+    SRCDIR:
+        Emacs source directory (default: current directory)
+    EMACSFLAVOR
+        name of the installed Emacs (default: emacs-snapshot)
+EOU
+}
+
+
+DEB_PACKAGE="emacs-snapshot_1.0_all.deb"
+_emacs_marker='lisp/startup.el'
+
+EMACS_SRC_DIR="${PWD}"
+EMACS_FLAVOR="emacs-snapshot"
+while [ ${#} -gt 0 ]; do
+    case "${1}" in
+        -h | -\? | --help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "[ERR] unsupported option: ${1@Q}"
+            echo
+            usage
+            exit 1
+            ;;
+        *)
+            if [ -f "${1:-}/${_emacs_marker}" ]; then
+                cd "${1%/}"
+                EMACS_SRC_DIR="${PWD}"
+            else
+                EMACS_FLAVOR="${1}"
+            fi
+            ;;
+    esac
+    shift
+done
+
+[ -f "${EMACS_SRC_DIR}/${_emacs_marker}" ] || {
+    echo "[ERR] ${PWD@Q} is not an Emacs source tree"
+    echo
+    usage
+    exit 1
+}
+
+[ "${EUID}" = "0" ] || {
+    if command -v sudo &> /dev/null; then
+        echo "[INF] You must be root to run this, restarting with sudo ..."
+        exec sudo JOB_COUNT="${JOB_COUNT-}" \
+             "${SCRIPT_DIR}/${SCRIPT_NAME}" "${EMACS_SRC_DIR}" "${EMACS_FLAVOR}"
+    else
+        echo "[ERR] You must be root to run this."
+        exit 1
+    fi
+}
 
 SRC_SHARE_DIR="/usr/local/share/emacs"
 DST_SHARE_DIR="/usr/share/${EMACS_FLAVOR}"
@@ -26,6 +78,15 @@ echo "[INF] Stage 1: Use 'make' to build/install Emacs from source tree ..."
 if [ -L "${SRC_SHARE_DIR}/site-lisp" ] &&
    [ "$(realpath "${SRC_SHARE_DIR}/site-lisp")" != "${DST_SHARE_DIR}/site-lisp" ]; then
     rm -v "${SRC_SHARE_DIR}/site-lisp"
+fi
+if [ -n "${SUDO_USER}" ]; then
+    # When running under sudo, build Emacs as original user to avoid creating
+    # build artefacts as superuser.
+    #
+    # Unfortunately, `make --question` doesn't work with the Emacs build system,
+    # otherwise we could check if a (re-)build is required.
+    [ -v JOB_COUNT ] || JOB_COUNT="$(($(nproc 2>/dev/null || echo 0)+1))"
+    sudo -u "${SUDO_USER}" make "${JOB_COUNT:+--jobs=${JOB_COUNT}}"
 fi
 make install
 VERSION="$(realpath /usr/local/bin/emacs | cut -d'-' -f2)"
@@ -138,6 +199,8 @@ echo "[INF] Stage 5: Install/update ${DST_SITE_START@Q} ..."
 # order to load '/usr/share/<emacs-flavor>/site-lisp/debian-startup.el' and run
 # the elisp `debian-startup' function during Emacs startup
 install --mode 644 --verbose "${SCRIPT_DIR}/site-start.el" "${DST_SITE_START}"
+# update `debian-emacs-flavor'
+sed -i -E "s,emacs-snapshot,${EMACS_FLAVOR}," "${DST_SITE_START}"
 echo "[INF] Stage 5: Done."
 echo
 

--- a/site-start.el
+++ b/site-start.el
@@ -1,4 +1,4 @@
-;;; debian-init.el --- Debian utilities
+;;; site-start.el --- Debian utilities
 
 ;;; Make sure that we have instrumented all Debian packages
 

--- a/site-start.el
+++ b/site-start.el
@@ -1,14 +1,33 @@
-;;; site-start.el --- Debian utilities
+;;; site-start.el --- add Debian specific steps to Emacs startup  -*- lexical-binding: t; -*-
 
-;;; Make sure that we have instrumented all Debian packages
+;;; Commentary:
+
+;; Make sure that Debian elisp packages get initialized (except when starting
+;; Emacs with -q/--no-init-file).
+
+;;; Code:
 
 ;; Load debian-startup.el and run startup
-(unless (boundp 'debian-emacs-flavor)
-  (load "debian-startup")
-  ;; Now instrument all of the packages
-  (defconst debian-emacs-flavor 'emacs-snapshot
-    "A symbol representing the particular debian flavor of emacs that's
-running.  Something like 'emacs20, 'xemacs20, etc.")
-  (debian-startup debian-emacs-flavor))
+(defconst debian-emacs-flavor 'emacs-snapshot
+  "A symbol representing the particular debian flavor of Emacs running.
+Something like \='emacs20, \='xemacs20, \='emacs-snapshot, etc.")
 
-(add-to-list 'load-path "/usr/share/emacs/site-lisp")
+;; When emacs was started with -q/--no-init-file, `init-user-file' gets set to
+;; nil. Use this to skip loading `debian-startup' (as in the original Debian
+;; emacs packages).
+(when init-file-user
+  (if (load "debian-startup" t t nil)
+      ;; Now instrument all of the packages
+      (debian-startup debian-emacs-flavor))
+
+  ;; Adding '/usr/share/emacs/site-lisp' should not be necessary, since
+  ;; /usr/share/<emacs-snapshot>/site-lisp is (indirectly) already in
+  ;; `load-path'. However, some packages refuse to install when
+  ;; `debian-emacs-flavor' is 'emacs-snapshot' (why?), so it might be better to
+  ;; keep it.
+  ;;
+  ;; Maybe there are to this downsides I'm not aware of, but that would be a
+  ;; good reason to use a flavor different from 'emacs-snapshot'.
+  (add-to-list 'load-path "/usr/share/emacs/site-lisp"))
+
+;;; site-start.el ends here


### PR DESCRIPTION
This PR includes the following new features:

- verify that script works on Debian forky
- no manual postprocessing
  - no links need to be fixed
  - nothing needs to be loaded into Emacs (done automatically via `site-start.el`)
- automatically re-run with sudo (if sudo is available)
- separate build and install steps to:
  - avoid creating build artefacts as superuser
  - run the build with multiple parallel make jobs (optional)
- `restore-emacs` can be started from anywhere (by providing the Emacs source tree location as command line option)
- add help/usage message to the `restore-emacs` script

Other changes:
- update README.md
- fix shellcheck issues
- allow changing the name of the installed Emacs flavor from the
  default (emacs-snapshot) - this is not fully tested, yet